### PR TITLE
Fix issue where left/right audio channels were swapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ backwards compatibility.
 ## Unreleased
 
 * Allow audio sampling rate of 96 kHz.
+* **Breaking** Fix issue where left/right audio channels were swapped
 
 ## 0.8.0
 

--- a/src/audio/interface.rs
+++ b/src/audio/interface.rs
@@ -120,7 +120,7 @@ impl Interface {
 
             let y0 = u24_to_f32(rx_y0);
             let y1 = u24_to_f32(rx_y1);
-            block[block_index] = (y1, y0);
+            block[block_index] = (y0, y1);
 
             dma_index += 2;
             block_index += 1;
@@ -136,7 +136,7 @@ impl Interface {
             let tx0: usize = dma_index + skip.0;
             let tx1: usize = tx0 + 1;
 
-            let (y0, y1) = block[block_index];
+            let (y1, y0) = block[block_index];
             unsafe { TX_BUFFER[tx0] = f32_to_u24(y0) };
             unsafe { TX_BUFFER[tx1] = f32_to_u24(y1) };
 


### PR DESCRIPTION
This PR fixes an issue where left and right audio output channels are swapped.

You can see the correct ordering is used for the audio inputs:

```rust
block[block_index] = (y1, y0);
``` 

But for audio outputs, the values in the pair are swapped:

```
let (y0, y1) = block[block_index];
```