### PR TITLE
Add `rust-toolchain` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ openocd.gdb
 RELEASE.md
 tmp/
 stm32h7x-orig.cfg
-rust-toolchain
 _docs/

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+
+[toolchain]
+channel = "1.85.0"
+components = ["rustfmt", "clippy"]
+targets = ["thumbv7em-none-eabihf"]


### PR DESCRIPTION
This PR adds a `rust-toolchain` to the repository.

I did noticed that `rust-toolchain` is gitignored. Yet, I find it it convenient to have around for new comers, since it ensures that:
1) you get a compiler that supports edition 2024
2) you get the toolchain for the correct target

